### PR TITLE
Tiny text fix in modifiers.md

### DIFF
--- a/src/quickstart/modifiers.md
+++ b/src/quickstart/modifiers.md
@@ -2,7 +2,7 @@
 
 Modifiers are used to customize the appearance and behavior of views in a declarative way. Many of the built-in modifiers in Vizia can be applied to any View, which includes built-in views as well as user-defined views.
 
-## Customizing the button with a modifier 
+## Customizing the label with a modifier 
 
 Applying modifiers to a view changes the properties of a view without rebuilding it. For example, we can use the `background_color()` modifier to set the background color of the label view:
 
@@ -13,7 +13,7 @@ Label::new(cx, "Hello Vizia")
 
 <img src="img/view_modifier.png" alt=""/>
 
-Note how this overrides the default background color of the button, which is provided by a CSS stylesheet.
+Note how this overrides the default background color of the label, which is provided by a CSS stylesheet.
 
 Multiple modifiers can be chained together to achieve more complex view configuration. Because modifiers are just changing the properties of a view, the order of modifiers is not important.
 


### PR DESCRIPTION
Text should refer to label, not button here.

On another note, why are most/all of the "basic" pages commented out? I couldn't track down when or why that happened.